### PR TITLE
update solution stacks

### DIFF
--- a/templates/fcrepo.yaml
+++ b/templates/fcrepo.yaml
@@ -173,7 +173,7 @@ Resources:
       - Namespace: aws:elb:listener:80
         OptionName: ListenerProtocol
         Value: HTTP
-      SolutionStackName: 64bit Amazon Linux 2017.03 v2.6.1 running Tomcat 8 Java 8
+      SolutionStackName: 64bit Amazon Linux 2017.03 v2.6.2 running Tomcat 8 Java 8
   FcrepoEnvironment:
     Type: AWS::ElasticBeanstalk::Environment
     Properties:

--- a/templates/solr.yaml
+++ b/templates/solr.yaml
@@ -219,7 +219,7 @@ Resources:
         - Namespace: aws:elb:listener:80
           OptionName: InstancePort
           Value: '8983'
-      SolutionStackName: 64bit Amazon Linux 2017.03 v2.7.1 running Multi-container Docker 17.03.1-ce (Generic)
+      SolutionStackName: 64bit Amazon Linux 2017.03 v2.7.2 running Multi-container Docker 17.03.1-ce (Generic)
   EBRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:

--- a/templates/webapp.yaml
+++ b/templates/webapp.yaml
@@ -227,7 +227,7 @@ Resources:
       - Namespace: aws:elasticbeanstalk:managedactions
         OptionName: PreferredStartTime
         Value: Sun:00:00
-      SolutionStackName: 64bit Amazon Linux 2017.03 v2.4.1 running Ruby 2.3 (Puma)
+      SolutionStackName: 64bit Amazon Linux 2017.03 v2.4.2 running Ruby 2.3 (Puma)
   WebappEnvironment:
     Type: AWS::ElasticBeanstalk::Environment
     Properties:

--- a/templates/zookeeper.yaml
+++ b/templates/zookeeper.yaml
@@ -202,7 +202,7 @@ Resources:
         - Namespace: aws:elasticbeanstalk:managedactions
           OptionName: ManagedActionsEnabled
           Value: 'false'
-      SolutionStackName: 64bit Amazon Linux 2017.03 v2.7.0 running Docker 17.03.1-ce
+      SolutionStackName: 64bit Amazon Linux 2017.03 v2.7.1 running Docker 17.03.1-ce
   EBRecordSet:
     Type: AWS::Route53::RecordSet
     Properties:


### PR DESCRIPTION
Fixed up stacks, the audit output is now:

```
templates/fcrepo.yaml: Solution Stack `64bit Amazon Linux 2017.03 v2.6.2 running Tomcat 8 Java 8': OK
templates/solr.yaml: Solution Stack `64bit Amazon Linux 2017.03 v2.7.2 running Multi-container Docker 17.03.1-ce (Generic)': OK
templates/webapp.yaml: Solution Stack `64bit Amazon Linux 2017.03 v2.4.2 running Ruby 2.3 (Puma)': OK
templates/worker.yaml: Solution Stack `64bit Amazon Linux 2017.03 v2.4.1 running Ruby 2.3 (Puma)': OK
templates/zookeeper.yaml: Solution Stack `64bit Amazon Linux 2017.03 v2.7.1 running Docker 17.03.1-ce': OK```